### PR TITLE
Add pycryptodome backend to compute keccak256 hash

### DIFF
--- a/eth_hash/backends/pycryptodome.py
+++ b/eth_hash/backends/pycryptodome.py
@@ -1,2 +1,9 @@
-def keccak256(prehash):
-    return b''
+from Crypto.Hash import (
+    keccak,
+)
+
+
+def keccak256(prehash: bytes) -> bytes:
+    hash = keccak.new(digest_bits=256)
+    hash.update(prehash)
+    return hash.digest()

--- a/eth_hash/main.py
+++ b/eth_hash/main.py
@@ -1,7 +1,8 @@
 class Keccak256:
     def __init__(self, backend):
         self.hasher = backend.keccak256
-        # TODO run assertion to validate hash once on load, after first backend set up
+
+        assert self.hasher(b'') == b"\xc5\xd2F\x01\x86\xf7#<\x92~}\xb2\xdc\xc7\x03\xc0\xe5\x00\xb6S\xca\x82';{\xfa\xd8\x04]\x85\xa4p"  # noqa: E501
 
     def __call__(self, preimage):
         if not isinstance(preimage, bytes):

--- a/setup.py
+++ b/setup.py
@@ -45,6 +45,7 @@ setup(
     url='https://github.com/ethereum/eth-hash',
     include_package_data=True,
     install_requires=[
+        "pycryptodome>=3.4.6",
     ],
     setup_requires=['setuptools-markdown'],
     extras_require=extras_require,


### PR DESCRIPTION
## What was wrong?

Moving the work here from this PR: https://github.com/ethereum/eth-bloom/pull/12
Refer to this comment to know we are doing this: https://github.com/ethereum/eth-bloom/pull/12/files#r166493846

## How was it fixed?

Added a new backend for `keccak256` using the `pycryptodome` package. We need to do this to add support for PyPy (3).

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://i.pinimg.com/736x/c2/ff/1c/c2ff1cabccb72e29806fbcab7ae906ec--cute-animal-quotes-animal-pics.jpg)
